### PR TITLE
Odkomentovat test názvu roury při alokaci

### DIFF
--- a/sources/kernel/src/process/resource_manager.cpp
+++ b/sources/kernel/src/process/resource_manager.cpp
@@ -153,7 +153,7 @@ CPipe* CProcess_Resource_Manager::Alloc_Pipe(const char* name, uint32_t pipe_siz
     {
         if (mPipes[i].alloc_count > 0)
         {
-            //if (strncmp(mPipes[i].name, name, Max_Pipe_Name_Length) == 0)
+            if (strncmp(mPipes[i].name, name, Max_Pipe_Name_Length) == 0)
             {
                 mPipes[i].alloc_count++;
                 return &mPipes[i].pipe;


### PR DESCRIPTION
V metodě alokace Pipe v  resource_manager.cpp byl zakomentován test názvu roury při prohledávání pole rour. Bez testu metoda vrátí první již alokovanou rouru a ne tu, která byla specifikována volajícícm procesem (v parametru name).